### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # daily-coding-problem
 
 Daily Coding Problem solutions in Python
+
+[![Run on Repl.it](https://repl.it/badge/github/teddy931130/daily-coding-problem)](https://repl.it/github/teddy931130/daily-coding-problem)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@teddy931130/daily-coding-problem).